### PR TITLE
Improve masked attention

### DIFF
--- a/histaug/train/models/abmil.py
+++ b/histaug/train/models/abmil.py
@@ -24,7 +24,7 @@ class AttentionMIL(nn.Module):
     def forward(self, feats, coords, mask, *args, **kwargs):
         embeddings = self.encoder(feats)  # B, N, D
         attention = self.attention(embeddings).squeeze(-1)  # B, N
-        attention = attention * mask  # B, N
+        attention = torch.masked_fill(attention, ~mask, -torch.inf)  # B, N
         attention = F.softmax(attention, dim=-1)  # B, N
         embeddings = embeddings * attention.unsqueeze(-1)  # B, N, D
         slide_tokens = embeddings.sum(dim=-2)  # B, D


### PR DESCRIPTION
Hi!

I've just read the paper and it is excellent! Answered so many questions I've had recently.

I've been looking at the ABMIL implementation and I'm a bit confused by the masked attention part.
If `mask` is a binary mask, then the multiplication by it effectively sets the masked elements to zero. 
However, `softmax` will still treat zeros as full-fledged elements, "unmasking" them.

Setting masked elements to `-inf` solves the issue.

 ```python
>>> a = torch.tensor([0.43, -0.21, 0.99, 0.32, -0.35, 0.04])
>>> mask = torch.tensor([True, True, True, False, False, False])

>>> a_masked_multiplication = a * mask
>>> a_masked_multiplication
tensor([ 0.4300, -0.2100,  0.9900,  0.0000, -0.0000,  0.0000])
>>> torch.softmax(a_masked_multiplication, dim=0)
tensor([0.1912, 0.1008, 0.3348, 0.1244, 0.1244, 0.1244])

>>> a_masked_inf = torch.masked_fill(a, ~mask, -torch.inf)
>>> a_masked_inf
tensor([ 0.4300, -0.2100,  0.9900,    -inf,    -inf,    -inf])
>>> torch.softmax(a_masked_inf, dim=0)
tensor([0.3051, 0.1609, 0.5341, 0.0000, 0.0000, 0.0000])
```

Please close this PR if I'm misinterpreting the context! 